### PR TITLE
Improve intersperse implementation

### DIFF
--- a/PublicExtension.playground/Pages/BidirectionalCollection.xcplaygroundpage/Contents.swift
+++ b/PublicExtension.playground/Pages/BidirectionalCollection.xcplaygroundpage/Contents.swift
@@ -4,7 +4,7 @@
 extension BidirectionalCollection where
     Iterator.Element: Equatable {
     
-    func intersperse(producer: () -> Iterator.Element) -> [Iterator.Element] {
+    func intersperse(producer: @autoclosure() -> Iterator.Element) -> [Iterator.Element] {
         var result = flatMap({ return [$0, producer()] })
         result.popLast()
         return result

--- a/PublicExtension.playground/Pages/BidirectionalCollection.xcplaygroundpage/Contents.swift
+++ b/PublicExtension.playground/Pages/BidirectionalCollection.xcplaygroundpage/Contents.swift
@@ -5,10 +5,8 @@ extension BidirectionalCollection where
     Iterator.Element: Equatable {
     
     func intersperse(producer: () -> Iterator.Element) -> [Iterator.Element] {
-        return reduce([]) { accumulated, next in
-            return accumulated +
-                [next] +
-                (next != last! ? [producer()] : [])
-        }
+        var result = flatMap({ return [$0, producer()] })
+        result.popLast()
+        return result
     }
 }


### PR DESCRIPTION
The current implementation suffers a bug with most value types (i.e Int, String). For example the snippet below:

```swift
let result = [10, 2, 8, 10, 16, 10].intersperse(producer: { return 0 })
```

will produce `[10, 2, 0, 8, 0, 10, 16, 0, 10]`, which is clearly wrong since 0 is not added after any object that is equal to the last element - in this case `10`.

The new implementation instead uses `flatMap` and `popLast` to fix this issue.

I also wrapped the `producer` closure with `@autoclosure` attribute here. This allows for more elegant constructions such as

```swift
[UILabel(), UILabel(), UILabel()].intersperse(producer: UIView())
```
