### PR TITLE
Add IndicesSubscript extension

### DIFF
--- a/PublicExtension.playground/Pages/Collection.xcplaygroundpage/Contents.swift
+++ b/PublicExtension.playground/Pages/Collection.xcplaygroundpage/Contents.swift
@@ -99,7 +99,7 @@ extension Collection
 }
 
 //: Credit to [@ericasadun](https://twitter.com/ericasadun)
-extension Collection where Iterator.Element: Comparable, Index: Integer {
+extension Collection where Iterator.Element: Comparable, Index: BinaryInteger {
     func element(after element: Iterator.Element) -> Iterator.Element? {
         guard let
             idx = index(of: element),
@@ -142,5 +142,13 @@ extension Collection {
         }
         
         return (matching, nonMatching)
+    }
+}
+
+//: Credit to [@iosartem](http://twitter.com/iosartem)
+extension Collection {
+
+    subscript(indices: [Index]) -> [Element] {
+        return indices.map { self[$0] }
     }
 }

--- a/PublicExtension.playground/Pages/IndicesSubscript.xcplaygroundpage/Contents.swift
+++ b/PublicExtension.playground/Pages/IndicesSubscript.xcplaygroundpage/Contents.swift
@@ -1,0 +1,9 @@
+//: [Table of Contents](Table%20of%20Contents)
+
+//: Credit to [@iosartem](http://twitter.com/iosartem)
+extension Array {
+
+    subscript(index: [Index]) -> [Element] {
+        return enumerated().filter { index.contains($0.0) }.map { $0.1 }
+    }
+}

--- a/PublicExtension.playground/Pages/IndicesSubscript.xcplaygroundpage/Contents.swift
+++ b/PublicExtension.playground/Pages/IndicesSubscript.xcplaygroundpage/Contents.swift
@@ -1,9 +1,0 @@
-//: [Table of Contents](Table%20of%20Contents)
-
-//: Credit to [@iosartem](http://twitter.com/iosartem)
-extension Array {
-
-    subscript(index: [Index]) -> [Element] {
-        return enumerated().filter { index.contains($0.0) }.map { $0.1 }
-    }
-}

--- a/PublicExtension.playground/Pages/Table of Contents.xcplaygroundpage/Contents.swift
+++ b/PublicExtension.playground/Pages/Table of Contents.xcplaygroundpage/Contents.swift
@@ -18,6 +18,7 @@ Public Extension Table of Contents
 - [Dictionary](Dictionary)
 - [ErrorType](ErrorType)
 - [FloatingPoint](FloatingPoint)
+- [IndicesSubscript](IndicesSubscript)
 - [Int](Int)
 - [OperationQueue](OperationQueue)
 - [Optional](Optional)
@@ -44,7 +45,7 @@ Public Extension Table of Contents
 - [UISplitViewController](UISplitViewController)
 - [UITableView](UITableView)
 - [UIView](UIView)
-- [UIWindow](UIWindow
+- [UIWindow](UIWindow)
 - [UnicodeScalar](UnicodeScalar)
 - [UserDefaults](UserDefaults)
 

--- a/PublicExtension.playground/Pages/Table of Contents.xcplaygroundpage/Contents.swift
+++ b/PublicExtension.playground/Pages/Table of Contents.xcplaygroundpage/Contents.swift
@@ -18,7 +18,6 @@ Public Extension Table of Contents
 - [Dictionary](Dictionary)
 - [ErrorType](ErrorType)
 - [FloatingPoint](FloatingPoint)
-- [IndicesSubscript](IndicesSubscript)
 - [Int](Int)
 - [OperationQueue](OperationQueue)
 - [Optional](Optional)

--- a/PublicExtension.playground/contents.xcplayground
+++ b/PublicExtension.playground/contents.xcplayground
@@ -11,6 +11,7 @@
         <page name='UIDynamicAnimator'/>
         <page name='UIView'/>
         <page name='UITableView'/>
+        <page name='IndicesSubscript'/>
         <page name='Int'/>
         <page name='UIImage'/>
         <page name='CGSize'/>
@@ -47,6 +48,5 @@
         <page name='UnicodeScalar'/>
         <page name='RandomAccessCollection'/>
         <page name='FloatingPoint'/>
-        <page name='IndicesSubscript'/>
     </pages>
 </playground>

--- a/PublicExtension.playground/contents.xcplayground
+++ b/PublicExtension.playground/contents.xcplayground
@@ -11,7 +11,6 @@
         <page name='UIDynamicAnimator'/>
         <page name='UIView'/>
         <page name='UITableView'/>
-        <page name='IndicesSubscript'/>
         <page name='Int'/>
         <page name='UIImage'/>
         <page name='CGSize'/>

--- a/PublicExtension.playground/contents.xcplayground
+++ b/PublicExtension.playground/contents.xcplayground
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<playground version='6.0' target-platform='ios' display-mode='raw'>
+<playground version='6.0' target-platform='ios' display-mode='rendered'>
     <pages>
         <page name='Table of Contents'/>
         <page name='UIEdgeInsets'/>
@@ -47,5 +47,6 @@
         <page name='UnicodeScalar'/>
         <page name='RandomAccessCollection'/>
         <page name='FloatingPoint'/>
+        <page name='IndicesSubscript'/>
     </pages>
 </playground>


### PR DESCRIPTION
Example of using:
```swift
let values = ["a", "b", "c"]
let indices = [0, 1]

print(values[indices])
```
Prints:
> ["a", "b"]

I added `Render Documentation` option enabled by default as well.